### PR TITLE
Add restart of single lifecycle node on failure instead of restarting…

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -26,6 +26,7 @@
 #include "nav2_util/lifecycle_service_client.hpp"
 #include "nav2_util/node_thread.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "nav2_msgs/srv/manage_lifecycle_nodes.hpp"
 #include "std_srvs/srv/trigger.hpp"
@@ -206,6 +207,9 @@ protected:
   rclcpp::TimerBase::SharedPtr bond_timer_;
   rclcpp::TimerBase::SharedPtr bond_respawn_timer_;
   std::chrono::milliseconds bond_timeout_;
+
+  /// @brief Publisher of the is restarting topic
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr is_restarting_pub_;
 
   // A map of all nodes to check bond connection
   std::map<std::string, std::shared_ptr<bond::Bond>> bond_map_;


### PR DESCRIPTION
Added custom restart of a single lifecycle node before restarting the entire stack.
If the single restart fails then the entire stack will be restarted.
