### PR TITLE
Working concurent local and global planner setup

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_local_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/truncate_path_local_action.hpp
@@ -53,6 +53,8 @@ public:
       BT::InputPort<nav_msgs::msg::Path>("input_path", "Original Path"),
       BT::OutputPort<nav_msgs::msg::Path>(
         "output_path", "Path truncated to a certain distance around robot"),
+      BT::OutputPort<geometry_msgs::msg::PoseStamped>(
+        "last_path_pose", "Last pose ot the truncated path"),
       BT::InputPort<double>(
         "distance_forward", 8.0,
         "Distance in forward direction"),

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -15,6 +15,15 @@
       <input_port name="server_timeout">Server timeout</input_port>
     </Action>
 
+    <Action ID="BackUpDirectional">
+      <input_port name="backup_dist">Distance to backup</input_port>
+      <input_port name="backup_speed">Speed at which to backup</input_port>
+      <input_port name="time_allowance">Allowed time for reversing</input_port>
+      <input_port name="server_name">Server name</input_port>
+      <input_port name="server_timeout">Server timeout</input_port>
+      <input_port name="truncated_path">PAth</input_port>
+    </Action>
+
     <Action ID="DriveOnHeading">
       <input_port name="dist_to_travel">Distance to travel</input_port>
       <input_port name="speed">Speed at which to travel</input_port>
@@ -54,6 +63,11 @@
     </Action>
 
     <Action ID="ClearEntireCostmap">
+      <input_port name="service_name">Service name</input_port>
+      <input_port name="server_timeout">Server timeout</input_port>
+    </Action>
+
+    <Action ID="CallTriggerService">
       <input_port name="service_name">Service name</input_port>
       <input_port name="server_timeout">Server timeout</input_port>
     </Action>

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -21,7 +21,7 @@
       <input_port name="time_allowance">Allowed time for reversing</input_port>
       <input_port name="server_name">Server name</input_port>
       <input_port name="server_timeout">Server timeout</input_port>
-      <input_port name="truncated_path">PAth</input_port>
+      <input_port name="truncated_path">Path</input_port>
     </Action>
 
     <Action ID="DriveOnHeading">

--- a/nav2_behavior_tree/plugins/action/truncate_path_local_action.cpp
+++ b/nav2_behavior_tree/plugins/action/truncate_path_local_action.cpp
@@ -67,6 +67,7 @@ inline BT::NodeStatus TruncatePathLocal::tick()
 
   if (path_.poses.empty()) {
     setOutput("output_path", path_);
+    setOutput("last_path_pose", path_.poses.back());
     return BT::NodeStatus::SUCCESS;
   }
 
@@ -101,6 +102,7 @@ inline BT::NodeStatus TruncatePathLocal::tick()
   output_path.poses = std::vector<geometry_msgs::msg::PoseStamped>(
     backward_pose_it.base(), forward_pose_it);
   setOutput("output_path", output_path);
+  setOutput("last_path_pose", output_path.poses.back());
 
   return BT::NodeStatus::SUCCESS;
 }

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
-#include <mutex>
+#include <shared_mutex>
 
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -233,7 +233,7 @@ protected:
 
   // Dynamic parameters handler
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
-  std::mutex dynamic_params_lock_;
+  std::shared_mutex dynamic_params_lock_;
 
   // Planner
   PlannerMap planners_;

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -187,6 +187,7 @@ protected:
 
   // Our action server implements the ComputePathToPose action
   std::unique_ptr<ActionServerToPose> action_server_pose_;
+  std::unique_ptr<ActionServerToPose> action_server_pose2_;
   std::unique_ptr<ActionServerThroughPoses> action_server_poses_;
 
   /**
@@ -194,6 +195,13 @@ protected:
    * ComputePathToPose
    */
   void computePlan();
+
+  /**
+   * @brief The action server callback which calls planner to get the path
+   * ComputePathToPose
+   */
+  void computePlan2();
+  
 
   /**
    * @brief The action server callback which calls planner to get the path

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -371,7 +371,7 @@ bool PlannerServer::validatePath(
 void
 PlannerServer::computePlanThroughPoses()
 {
-  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+  std::shared_lock<std::shared_mutex> lock(dynamic_params_lock_);
 
   auto start_time = this->now();
 
@@ -463,7 +463,7 @@ PlannerServer::computePlanThroughPoses()
 void
 PlannerServer::computePlan()
 {
-  // std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+  std::shared_lock<std::shared_mutex>  lock(dynamic_params_lock_);
 
   auto start_time = this->now();
 
@@ -523,7 +523,7 @@ PlannerServer::computePlan()
 void
 PlannerServer::computePlan2()
 {
-  // std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+  std::shared_lock<std::shared_mutex>  lock(dynamic_params_lock_);
 
   auto start_time = this->now();
 
@@ -677,7 +677,7 @@ void PlannerServer::isPathValid(
 rcl_interfaces::msg::SetParametersResult
 PlannerServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters)
 {
-  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+  std::unique_lock<std::shared_mutex> lock(dynamic_params_lock_);
   rcl_interfaces::msg::SetParametersResult result;
 
   for (auto parameter : parameters) {

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <thread>
 
 #include "builtin_interfaces/msg/duration.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
@@ -147,6 +148,15 @@ PlannerServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     std::chrono::milliseconds(500),
     true);
 
+  // Create the action servers for path planning to a pose and through poses
+  action_server_pose2_ = std::make_unique<ActionServerToPose>(
+    shared_from_this(),
+    "compute_path_to_pose2",
+    std::bind(&PlannerServer::computePlan2, this),
+    nullptr,
+    std::chrono::milliseconds(500),
+    true);
+
   action_server_poses_ = std::make_unique<ActionServerThroughPoses>(
     shared_from_this(),
     "compute_path_through_poses",
@@ -165,6 +175,7 @@ PlannerServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
 
   plan_publisher_->on_activate();
   action_server_pose_->activate();
+  action_server_pose2_->activate();
   action_server_poses_->activate();
   costmap_ros_->activate();
 
@@ -197,6 +208,7 @@ PlannerServer::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   RCLCPP_INFO(get_logger(), "Deactivating");
 
   action_server_pose_->deactivate();
+  action_server_pose2_->deactivate();
   action_server_poses_->deactivate();
   plan_publisher_->on_deactivate();
 
@@ -228,6 +240,7 @@ PlannerServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   RCLCPP_INFO(get_logger(), "Cleaning up");
 
   action_server_pose_.reset();
+  action_server_pose2_.reset();
   action_server_poses_.reset();
   plan_publisher_.reset();
   tf_.reset();
@@ -450,14 +463,13 @@ PlannerServer::computePlanThroughPoses()
 void
 PlannerServer::computePlan()
 {
-  std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+  // std::lock_guard<std::mutex> lock(dynamic_params_lock_);
 
   auto start_time = this->now();
 
   // Initialize the ComputePathToPose goal and result
   auto goal = action_server_pose_->get_current_goal();
   auto result = std::make_shared<ActionToPose::Result>();
-
   try {
     if (isServerInactive(action_server_pose_) || isCancelRequested(action_server_pose_)) {
       return;
@@ -508,13 +520,75 @@ PlannerServer::computePlan()
   }
 }
 
+void
+PlannerServer::computePlan2()
+{
+  // std::lock_guard<std::mutex> lock(dynamic_params_lock_);
+
+  auto start_time = this->now();
+
+  // Initialize the ComputePathToPose goal and result
+  auto goal = action_server_pose2_->get_current_goal();
+  auto result = std::make_shared<ActionToPose::Result>();
+
+  try {
+    if (isServerInactive(action_server_pose2_) || isCancelRequested(action_server_pose2_)) {
+      return;
+    }
+
+    waitForCostmap();
+
+    getPreemptedGoalIfRequested(action_server_pose2_, goal);
+
+
+    // Use start pose if provided otherwise use current robot pose
+    geometry_msgs::msg::PoseStamped start;
+    if (!getStartPose(action_server_pose2_, goal, start)) {
+      return;
+    }
+
+    // Transform them into the global frame
+    geometry_msgs::msg::PoseStamped goal_pose = goal->goal;
+    if (!transformPosesToGlobalFrame(action_server_pose2_, start, goal_pose)) {
+      return;
+    }  
+
+    result->path = getPlan(start, goal_pose, goal->planner_id); 
+
+    if (!validatePath(action_server_pose2_, goal_pose, result->path, goal->planner_id)) {
+      return;
+    }
+
+    // Publish the plan for visualization purposes
+    publishPlan(result->path);
+
+    auto cycle_duration = this->now() - start_time;
+    result->planning_time = cycle_duration;
+
+    if (max_planner_duration_ && cycle_duration.seconds() > max_planner_duration_) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Planner loop missed its desired rate of %.4f Hz. Current loop rate is %.4f Hz",
+        1 / max_planner_duration_, 1 / cycle_duration.seconds());
+    }
+
+    action_server_pose2_->succeeded_current(result);
+  } catch (std::exception & ex) {
+    RCLCPP_WARN(
+      get_logger(), "%s plugin failed to plan calculation to (%.2f, %.2f): \"%s\"",
+      goal->planner_id.c_str(), goal->goal.pose.position.x,
+      goal->goal.pose.position.y, ex.what());
+    action_server_pose2_->terminate_current();
+  }
+}
+
 nav_msgs::msg::Path
 PlannerServer::getPlan(
   const geometry_msgs::msg::PoseStamped & start,
   const geometry_msgs::msg::PoseStamped & goal,
   const std::string & planner_id)
 {
-  RCLCPP_DEBUG(
+  RCLCPP_INFO(
     get_logger(), "Attempting to a find path from (%.2f, %.2f) to "
     "(%.2f, %.2f).", start.pose.position.x, start.pose.position.y,
     goal.pose.position.x, goal.pose.position.y);

--- a/nav2_smac_planner/include/nav2_smac_planner/node_2d.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_2d.hpp
@@ -288,8 +288,8 @@ public:
 
   Node2D * parent;
   Coordinates pose;
-  static float cost_travel_multiplier;
-  static std::vector<int> _neighbors_grid_offsets;
+  thread_local static float cost_travel_multiplier;
+  thread_local static std::vector<int> _neighbors_grid_offsets;
 
 private:
   float _cell_cost;

--- a/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_hybrid.hpp
@@ -478,16 +478,16 @@ public:
   Coordinates pose;
 
   // Constants required across all nodes but don't want to allocate more than once
-  static float travel_distance_cost;
-  static HybridMotionTable motion_table;
+  thread_local static float travel_distance_cost;
+  thread_local static HybridMotionTable motion_table;
   // Wavefront lookup and queue for continuing to expand as needed
-  static LookupTable obstacle_heuristic_lookup_table;
-  static ObstacleHeuristicQueue obstacle_heuristic_queue;
+  thread_local static LookupTable obstacle_heuristic_lookup_table;
+  thread_local static ObstacleHeuristicQueue obstacle_heuristic_queue;
 
-  static std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros;
+  thread_local static std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros;
   // Dubin / Reeds-Shepp lookup and size for dereferencing
-  static LookupTable dist_heuristic_lookup_table;
-  static float size_lookup;
+  thread_local static LookupTable dist_heuristic_lookup_table;
+  thread_local static float size_lookup;
 
 private:
   float _cell_cost;

--- a/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/node_lattice.hpp
@@ -424,10 +424,10 @@ public:
 
   NodeLattice * parent;
   Coordinates pose;
-  static LatticeMotionTable motion_table;
+  thread_local static LatticeMotionTable motion_table;
   // Dubin / Reeds-Shepp lookup and size for dereferencing
-  static LookupTable dist_heuristic_lookup_table;
-  static float size_lookup;
+  thread_local static LookupTable dist_heuristic_lookup_table;
+  thread_local static float size_lookup;
 
 private:
   float _cell_cost;

--- a/nav2_smac_planner/include/nav2_smac_planner/thirdparty/robin_hood.h
+++ b/nav2_smac_planner/include/nav2_smac_planner/thirdparty/robin_hood.h
@@ -87,7 +87,7 @@ inline std::ostream& operator<<(std::ostream& os, Counts const& c) {
 }
 
 static Counts& counts() {
-    static Counts counts{};
+    thread_local Counts counts{};
     return counts;
 }
 }  // namespace robin_hood

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -121,8 +121,8 @@ void AStarAlgorithm<NodeT>::setCollisionChecker(GridCollisionChecker * collision
   if (getSizeX() != x_size || getSizeY() != y_size) {
     _x_size = x_size;
     _y_size = y_size;
-    NodeT::initMotionModel(_motion_model, _x_size, _y_size, _dim3_size, _search_info);
   }
+  NodeT::initMotionModel(_motion_model, _x_size, _y_size, _dim3_size, _search_info);
   _expander->setCollisionChecker(_collision_checker);
 }
 
@@ -312,9 +312,14 @@ bool AStarAlgorithm<NodeT>::areInputsValid()
   }
 
   // Check if points were filled in
-  if (!_start || _goal_manager.goalsIsEmpty()) {
-    throw std::runtime_error("Failed to compute path, no valid start or goal given.");
+  if (!_start) {
+    throw std::runtime_error("Failed to compute path, no valid start given.");
   }
+
+  if (_goal_manager.goalsIsEmpty()) {
+    throw std::runtime_error("Failed to compute path, no valid goal given.");
+  }
+
 
   // remove invalid goals
   _goal_manager.removeInvalidGoals(getToleranceHeuristic(), _collision_checker, _traverse_unknown);
@@ -346,8 +351,8 @@ bool AStarAlgorithm<NodeT>::createPath(
 
   #if VISUALIZE_PLANNER_EXPANSIONS
     // DEBUG: Create publisher for visualizing expansions
-    static auto planner_expansions_node = std::make_shared<rclcpp::Node>("planner_expansions");
-    static auto planner_expansions_pub = planner_expansions_node->create_publisher<geometry_msgs::msg::PoseArray>("planner_expansions", 1);
+    thread_local auto planner_expansions_node = std::make_shared<rclcpp::Node>("planner_expansions");
+    thread_local auto planner_expansions_pub = planner_expansions_node->create_publisher<geometry_msgs::msg::PoseArray>("planner_expansions", 1);
     geometry_msgs::msg::PoseArray planner_expansions_msg;
     geometry_msgs::msg::PoseArray recent_expansions_msg;
     geometry_msgs::msg::Pose planner_expansions_pose;

--- a/nav2_smac_planner/src/analytic_expansion.cpp
+++ b/nav2_smac_planner/src/analytic_expansion.cpp
@@ -64,7 +64,7 @@ typename AnalyticExpansion<NodeT>::NodePtr AnalyticExpansion<NodeT>::tryAnalytic
     NodePtr current_best_goal = nullptr;
     NodePtr current_best_node = nullptr;
     float current_best_score = std::numeric_limits<float>::max();
-
+  
     closest_distance = std::min(
       closest_distance,
       static_cast<int>(NodeT::getHeuristicCost(node_coords, goals_coords)));
@@ -171,7 +171,7 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
   const NodeGetter & node_getter,
   const ompl::base::StateSpacePtr & state_space)
 {
-  static ompl::base::ScopedState<> from(state_space), to(state_space), s(state_space);
+  thread_local ompl::base::ScopedState<> from(state_space), to(state_space), s(state_space);
   from[0] = node->pose.x;
   from[1] = node->pose.y;
   from[2] = node->motion_table.getAngleFromBin(node->pose.theta);

--- a/nav2_smac_planner/src/node_2d.cpp
+++ b/nav2_smac_planner/src/node_2d.cpp
@@ -22,8 +22,8 @@ namespace nav2_smac_planner
 {
 
 // defining static member for all instance to share
-std::vector<int> Node2D::_neighbors_grid_offsets;
-float Node2D::cost_travel_multiplier = 2.0;
+thread_local std::vector<int> Node2D::_neighbors_grid_offsets;
+thread_local float Node2D::cost_travel_multiplier = 2.0;
 
 Node2D::Node2D(const uint64_t index)
 : parent(nullptr),

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -34,15 +34,15 @@ using namespace std::chrono;  // NOLINT
 namespace nav2_smac_planner
 {
 
+// WE DO NOT WANT TO SHARE FOR MULTI THREAD APPS
 // defining static member for all instance to share
-LookupTable NodeHybrid::obstacle_heuristic_lookup_table;
-float NodeHybrid::travel_distance_cost = sqrtf(2.0f);
-HybridMotionTable NodeHybrid::motion_table;
-float NodeHybrid::size_lookup = 25;
-LookupTable NodeHybrid::dist_heuristic_lookup_table;
-std::shared_ptr<nav2_costmap_2d::Costmap2DROS> NodeHybrid::costmap_ros = nullptr;
-
-ObstacleHeuristicQueue NodeHybrid::obstacle_heuristic_queue;
+thread_local LookupTable NodeHybrid::obstacle_heuristic_lookup_table;
+thread_local float NodeHybrid::travel_distance_cost = sqrtf(2.0f);
+thread_local HybridMotionTable NodeHybrid::motion_table;
+thread_local float NodeHybrid::size_lookup = 25;
+thread_local LookupTable NodeHybrid::dist_heuristic_lookup_table;
+thread_local std::shared_ptr<nav2_costmap_2d::Costmap2DROS> NodeHybrid::costmap_ros = nullptr;
+thread_local ObstacleHeuristicQueue NodeHybrid::obstacle_heuristic_queue;
 
 // Each of these tables are the projected motion models through
 // time and space applied to the search on the current node in
@@ -775,7 +775,7 @@ float NodeHybrid::getDistanceHeuristic(
   } else if (obstacle_heuristic <= 0.0) {
     // If no obstacle heuristic value, must have some H to use
     // In nominal situations, this should never be called.
-    static ompl::base::ScopedState<> from(motion_table.state_space), to(motion_table.state_space);
+    thread_local ompl::base::ScopedState<> from(motion_table.state_space), to(motion_table.state_space);
     to[0] = goal_coords.x;
     to[1] = goal_coords.y;
     to[2] = goal_coords.theta * motion_table.num_angle_quantization;

--- a/nav2_smac_planner/src/node_hybrid.cpp
+++ b/nav2_smac_planner/src/node_hybrid.cpp
@@ -34,7 +34,6 @@ using namespace std::chrono;  // NOLINT
 namespace nav2_smac_planner
 {
 
-// WE DO NOT WANT TO SHARE FOR MULTI THREAD APPS
 // defining static member for all instance to share
 thread_local LookupTable NodeHybrid::obstacle_heuristic_lookup_table;
 thread_local float NodeHybrid::travel_distance_cost = sqrtf(2.0f);

--- a/nav2_smac_planner/src/node_lattice.cpp
+++ b/nav2_smac_planner/src/node_lattice.cpp
@@ -35,9 +35,9 @@ namespace nav2_smac_planner
 {
 
 // defining static member for all instance to share
-LatticeMotionTable NodeLattice::motion_table;
-float NodeLattice::size_lookup = 25;
-LookupTable NodeLattice::dist_heuristic_lookup_table;
+thread_local LatticeMotionTable NodeLattice::motion_table;
+thread_local float NodeLattice::size_lookup = 25;
+thread_local LookupTable NodeLattice::dist_heuristic_lookup_table;
 
 // Each of these tables are the projected motion models through
 // time and space applied to the search on the current node in
@@ -429,7 +429,7 @@ float NodeLattice::getDistanceHeuristic(
       theta_pos;
     motion_heuristic = dist_heuristic_lookup_table[index];
   } else if (obstacle_heuristic == 0.0) {
-    static ompl::base::ScopedState<> from(motion_table.state_space), to(motion_table.state_space);
+    thread_local ompl::base::ScopedState<> from(motion_table.state_space), to(motion_table.state_space);
     to[0] = goal_coords.x;
     to[1] = goal_coords.y;
     to[2] = motion_table.getAngleFromBin(goal_coords.theta);

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -399,7 +399,6 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
 
   if (_costmap_downsampler) {
     costmap = _costmap_downsampler->downsample(_downsampling_factor);
-    _collision_checker.setCostmap(costmap);
   }
 
   _collision_checker.setCostmap(costmap);
@@ -423,9 +422,6 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
             "Start Coordinates of(" + std::to_string(start.pose.position.x) + ", " +
             std::to_string(start.pose.position.y) + ") was outside bounds");
   }
-
-  // Previously locked here
-  // lock.unlock();
 
   double orientation_bin = std::round(tf2::getYaw(start.pose.orientation) / _angle_bin_size);
   while (orientation_bin < 0.0) {
@@ -457,7 +453,6 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
     orientation_bin -= static_cast<float>(_angle_quantizations);
   }
 
-  /// POSSIBLE issue here
   _a_star->setGoal(mx_goal, my_goal, static_cast<unsigned int>(orientation_bin),
     _goal_heading_mode, _coarse_search_resolution);
 

--- a/nav2_smac_planner/src/smoother.cpp
+++ b/nav2_smac_planner/src/smoother.cpp
@@ -330,7 +330,7 @@ void Smoother::findBoundaryExpansion(
   BoundaryExpansion & expansion,
   const nav2_costmap_2d::Costmap2D * costmap)
 {
-  static ompl::base::ScopedState<> from(state_space_), to(state_space_), s(state_space_);
+  thread_local ompl::base::ScopedState<> from(state_space_), to(state_space_), s(state_space_);
 
   from[0] = start.position.x;
   from[1] = start.position.y;


### PR DESCRIPTION
- Modified the truncate path local to return the last path point as well
- Added a second instance of ActionServer to planner_server as compute_path_to_pose2. This is the cleanest way to add another thread on which a second instance of the planner can be executed as each instance of ActionServer creates its own thread.
- Switched static vars in the smac planner to thread_local static to avoid mixing up between planner instances
- Fixed some of the init steps to account for the need of initialization of the motion model on each thread spawn
- Added copying of the costmap before starting to plan to allow the release of the Costmap2D lock before starting to plan.