### PR TITLE
GetBackupPose and TimeoutController BT nodes

### DIFF
--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -159,6 +159,9 @@ list(APPEND plugin_libs nav2_distance_controller_bt_node)
 add_library(nav2_speed_controller_bt_node SHARED plugins/decorator/speed_controller.cpp)
 list(APPEND plugin_libs nav2_speed_controller_bt_node)
 
+add_library(nav2_timeout_controller_bt_node SHARED plugins/decorator/timeout_controller.cpp)
+list(APPEND plugin_libs nav2_timeout_controller_bt_node)
+
 add_library(nav2_truncate_path_action_bt_node SHARED plugins/action/truncate_path_action.cpp)
 list(APPEND plugin_libs nav2_truncate_path_action_bt_node)
 

--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -186,6 +186,9 @@ list(APPEND plugin_libs nav2_remove_passed_goals_action_bt_node)
 add_library(nav2_get_pose_from_path_action_bt_node SHARED plugins/action/get_pose_from_path_action.cpp)
 list(APPEND plugin_libs nav2_get_pose_from_path_action_bt_node)
 
+add_library(nav2_get_backup_pose_action_bt_node SHARED plugins/action/get_backup_pose_action.cpp)
+list(APPEND plugin_libs nav2_get_backup_pose_action_bt_node)
+
 add_library(nav2_pipeline_sequence_bt_node SHARED plugins/control/pipeline_sequence.cpp)
 list(APPEND plugin_libs nav2_pipeline_sequence_bt_node)
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/get_backup_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/get_backup_pose_action.hpp
@@ -1,0 +1,57 @@
+#ifndef NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__GET_BACKUP_POSE_ACTION_HPP_
+#define NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__GET_BACKUP_POSE_ACTION_HPP_
+
+#include <vector>
+#include <memory>
+#include <string>
+#include <queue>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav2_util/geometry_utils.hpp"
+#include "nav2_util/robot_utils.hpp"
+#include "behaviortree_cpp_v3/action_node.h"
+#include "nav_msgs/msg/path.h"
+
+namespace nav2_behavior_tree
+{
+
+class GetBackupPoseAction : public BT::ActionNodeBase
+{
+public:
+  GetBackupPoseAction(
+    const std::string & xml_tag_name,
+    const BT::NodeConfiguration & conf);
+
+  /**
+   * @brief Creates list of BT ports
+   * @return BT::PortsList Containing node-specific ports
+   */
+  static BT::PortsList providedPorts()
+  {
+    return {
+      BT::OutputPort<geometry_msgs::msg::PoseStamped>("output_pose", "Previous robot pose (backup_distance behind)"),
+      BT::InputPort<double>("backup_distance", 0.0, "Minimum distance from current pose to consider"),
+      BT::InputPort<double>("dist_threshold", 0.1, "How often to check for a new backup pose"),
+      BT::InputPort<std::string>("global_frame", std::string("map"), "Global frame"),
+      BT::InputPort<std::string>("robot_frame", std::string("base_link"), "Robot base frame")
+    };
+  }
+
+private:
+  void halt() override {}
+  BT::NodeStatus tick() override;
+  void publishPose(const geometry_msgs::msg::PoseStamped & pose);
+
+  rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<tf2_ros::Buffer> tf_;
+  double transform_tolerance_;
+  double backup_distance_, dist_threshold_;
+  std::string global_frame_, robot_frame_;
+  std::vector<geometry_msgs::msg::PoseStamped> previous_poses_;
+  geometry_msgs::msg::PoseStamped previous_pose_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
+};
+
+}  // namespace nav2_behavior_tree
+
+#endif  // NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__GET_BACKUP_POSE_ACTION_HPP_

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/timeout_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/timeout_controller.hpp
@@ -8,17 +8,38 @@
 namespace nav2_behavior_tree
 {
 
+/**
+ * @brief A BT::DecoratorNode that ticks its child with every execution
+ * until it returns SUCCESS/FAILURE or timeout is achieved.
+ * 
+ * Returns BT::NodeStatus::RUNNING,
+ * its child final state if finished, or
+ * BT::NodeStatus::FAILURE on timeout. 
+ */
 class TimeoutController : public BT::DecoratorNode
 {
 public:
+  /**
+   * @brief A constructor for nav2_behavior_tree::TimeoutController
+   * @param name Name for the XML tag for this node
+   * @param conf BT node configuration
+   */
   TimeoutController(const std::string & name, const BT::NodeConfiguration & conf);
 
+  /**
+   * @brief Creates list of BT ports
+   * @return BT::PortsList Containing node-specific ports
+   */
   static BT::PortsList providedPorts()
   {
-    return { BT::InputPort<double>("timeout", 0.0, "TimeoutController in seconds") };
+    return { BT::InputPort<double>("timeout", 0.0, "Time in seconds to return FAILURE if the child keeps on RUNNING") };
   }
 
 private:
+  /**
+   * @brief The main override required by a BT action
+   * @return BT::NodeStatus Status of tick execution
+   */
   BT::NodeStatus tick() override;
 
   rclcpp::Node::SharedPtr node_;

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/timeout_controller.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/timeout_controller.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+#include <memory>
+#include "behaviortree_cpp_v3/decorator_node.h"
+#include "rclcpp/rclcpp.hpp"
+
+namespace nav2_behavior_tree
+{
+
+class TimeoutController : public BT::DecoratorNode
+{
+public:
+  TimeoutController(const std::string & name, const BT::NodeConfiguration & conf);
+
+  static BT::PortsList providedPorts()
+  {
+    return { BT::InputPort<double>("timeout", 0.0, "TimeoutController in seconds") };
+  }
+
+private:
+  BT::NodeStatus tick() override;
+
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Time start_time_;
+  double timeout_;
+  bool timer_started_;
+};
+
+}  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -222,8 +222,8 @@
     </Action>
 
     <Action ID="GetBackupPose">
-      <output_port name="output_pose">Previous robot pose (backup_distance behind)</output_port>
-      <input_port name="backup_distance">Minimum distance from current pose to consider</input_port>
+      <output_port name="output_pose">A previous robot pose in a backup_distance behind current position</output_port>
+      <input_port name="backup_distance">Distance of the backup pose behind the robot</input_port>
       <input_port name="dist_threshold">How often to check for a new backup pose</input_port>
       <input_port name="global_frame">Reference frame to check in</input_port>
       <input_port name="robot_frame">Robot frame to check relative to global_frame</input_port>
@@ -306,7 +306,7 @@
     </Decorator>
 
     <Decorator ID="TimeoutController">
-      <input_port name="timeout">Time to raport failure</input_port>
+      <input_port name="timeout">Time in seconds to return FAILURE if the child keeps on RUNNING</input_port>
     </Decorator>
 
     <Decorator ID="SingleTrigger">

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -305,6 +305,10 @@
       <input_port name="robot_base_frame">Robot base frame</input_port>
     </Decorator>
 
+    <Decorator ID="TimeoutController">
+      <input_port name="timeout">Time to raport failure</input_port>
+    </Decorator>
+
     <Decorator ID="SingleTrigger">
     </Decorator>
 

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -221,6 +221,14 @@
       <input_port name="server_timeout">Server timeout</input_port>
     </Action>
 
+    <Action ID="GetBackupPose">
+      <output_port name="output_pose">Previous robot pose (backup_distance behind)</output_port>
+      <input_port name="backup_distance">Minimum distance from current pose to consider</input_port>
+      <input_port name="dist_threshold">How often to check for a new backup pose</input_port>
+      <input_port name="global_frame">Reference frame to check in</input_port>
+      <input_port name="robot_frame">Robot frame to check relative to global_frame</input_port>
+    </Action>
+
     <!-- ############################### CONDITION NODES ############################## -->
     <Condition ID="GoalReached">
         <input_port name="goal">Destination</input_port>

--- a/nav2_behavior_tree/plugins/action/get_backup_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/get_backup_pose_action.cpp
@@ -1,0 +1,93 @@
+#include <string>
+#include <memory>
+#include <limits>
+
+#include "nav_msgs/msg/path.hpp"
+#include "nav2_util/geometry_utils.hpp"
+
+#include "nav2_behavior_tree/plugins/action/get_backup_pose_action.hpp"
+
+namespace nav2_behavior_tree
+{
+
+GetBackupPoseAction::GetBackupPoseAction(
+  const std::string & name,
+  const BT::NodeConfiguration & conf)
+: BT::ActionNodeBase(name, conf),
+  transform_tolerance_(0.1),
+  backup_distance_(0.0),
+  dist_threshold_(0.1),
+  global_frame_("map"),
+  robot_frame_("base_link")
+{
+  getInput("backup_distance", backup_distance_);
+  getInput("dist_threshold", dist_threshold_);
+  getInput("global_frame", global_frame_);
+  getInput("robot_frame", robot_frame_);
+  node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+  tf_ = config().blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
+  node_->get_parameter("transform_tolerance", transform_tolerance_);
+  pose_publisher_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>("backup_pose", 1);
+}
+
+inline BT::NodeStatus GetBackupPoseAction::tick()
+{
+  // Get current pose
+  geometry_msgs::msg::PoseStamped current_pose;
+  if (!nav2_util::getCurrentPose(
+      current_pose, *tf_, global_frame_, robot_frame_,
+      transform_tolerance_))
+  {
+    RCLCPP_ERROR(node_->get_logger(), "Current robot pose is not available.");
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Continue ticking until the distance exceeds predefined dist_threshold
+  if (nav2_util::geometry_utils::euclidean_distance(current_pose, previous_pose_) < dist_threshold_) {
+    return BT::NodeStatus::SUCCESS;  // Let the BT run unaffected
+  }
+
+  // Find backup pose within distance +/- dist_threshold and forget outdated ones
+  for (auto it_pose = previous_poses_.begin(); it_pose != previous_poses_.end(); ) {
+    double it_distance = nav2_util::geometry_utils::euclidean_distance(current_pose, *it_pose);
+    if (it_distance >= backup_distance_ - dist_threshold_ && it_distance <= backup_distance_ + dist_threshold_) {
+      setOutput("output_pose", *it_pose);
+      publishPose(*it_pose);
+      previous_poses_.erase(it_pose);
+      break;
+    } else if (it_distance > backup_distance_ + dist_threshold_) {
+      it_pose = previous_poses_.erase(it_pose);
+    } else {
+      it_pose++;
+    }
+  }
+
+  // Reset condition: use current pose if there's nothing within reach
+  if (previous_poses_.size() == 0) {
+      setOutput("output_pose", current_pose);
+      publishPose(current_pose);
+  }
+
+  // Remember the current pose for future search
+  previous_pose_ = current_pose;
+  previous_poses_.emplace_back(current_pose);
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+void GetBackupPoseAction::publishPose(const geometry_msgs::msg::PoseStamped & pose)
+{
+  auto msg = std::make_unique<geometry_msgs::msg::PoseStamped>(pose);
+  if (pose_publisher_->get_subscription_count() > 0) {
+    pose_publisher_->publish(std::move(msg));
+  }
+}
+
+
+}  // namespace nav2_behavior_tree
+
+#include "behaviortree_cpp_v3/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<nav2_behavior_tree::GetBackupPoseAction>("GetBackupPose");
+}

--- a/nav2_behavior_tree/plugins/action/truncate_path_local_action.cpp
+++ b/nav2_behavior_tree/plugins/action/truncate_path_local_action.cpp
@@ -67,7 +67,7 @@ inline BT::NodeStatus TruncatePathLocal::tick()
 
   if (path_.poses.empty()) {
     setOutput("output_path", path_);
-    setOutput("last_path_pose", path_.poses.back());
+    setOutput("last_path_pose", pose);
     return BT::NodeStatus::SUCCESS;
   }
 

--- a/nav2_behavior_tree/plugins/decorator/timeout_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/timeout_controller.cpp
@@ -1,0 +1,53 @@
+#include "nav2_behavior_tree/plugins/decorator/timeout_controller.hpp"
+
+namespace nav2_behavior_tree
+{
+
+TimeoutController::TimeoutController(
+  const std::string & name,
+  const BT::NodeConfiguration & conf)
+: BT::DecoratorNode(name, conf),
+  timeout_(0.0),
+  timer_started_(false)
+{
+  node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+  getInput("timeout", timeout_);
+  if (timeout_ <= 0.0) {
+    throw BT::BehaviorTreeException("TimeoutController node must have timeout > 0.0");
+  }
+}
+
+BT::NodeStatus TimeoutController::tick()
+{
+  if (!timer_started_ || status() == BT::NodeStatus::IDLE) {
+    start_time_ = node_->now();
+    timer_started_ = true;
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Timeout started counting until " << timeout_ << "s...");
+  }
+
+  setStatus(BT::NodeStatus::RUNNING);
+
+  auto elapsed = node_->now() - start_time_;
+  if (elapsed.seconds() > timeout_) {
+    timer_started_ = false;
+    return BT::NodeStatus::FAILURE;
+    RCLCPP_WARN_STREAM(node_->get_logger(), "Timeout elapsed, failing the BT!");
+  }
+
+  BT::NodeStatus child_state = child_node_->executeTick();
+
+  if (child_state == BT::NodeStatus::SUCCESS || child_state == BT::NodeStatus::FAILURE) {
+    timer_started_ = false;
+    return child_state;
+  }
+
+  return BT::NodeStatus::RUNNING;
+}
+
+}  // namespace nav2_behavior_tree
+
+#include "behaviortree_cpp_v3/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<nav2_behavior_tree::TimeoutController>("TimeoutController");
+}

--- a/nav2_behavior_tree/plugins/decorator/timeout_controller.cpp
+++ b/nav2_behavior_tree/plugins/decorator/timeout_controller.cpp
@@ -30,8 +30,8 @@ BT::NodeStatus TimeoutController::tick()
   auto elapsed = node_->now() - start_time_;
   if (elapsed.seconds() > timeout_) {
     timer_started_ = false;
+    RCLCPP_WARN_STREAM(node_->get_logger(), "Timeout elapsed, TimeoutController returning FAILURE!");
     return BT::NodeStatus::FAILURE;
-    RCLCPP_WARN_STREAM(node_->get_logger(), "Timeout elapsed, failing the BT!");
   }
 
   BT::NodeStatus child_state = child_node_->executeTick();

--- a/nav2_bt_navigator/src/bt_navigator.cpp
+++ b/nav2_bt_navigator/src/bt_navigator.cpp
@@ -82,6 +82,7 @@ BtNavigator::BtNavigator(rclcpp::NodeOptions options)
     "nav2_back_up_cancel_bt_node",
     "nav2_drive_on_heading_cancel_bt_node",
     "nav2_is_battery_charging_condition_bt_node"
+    "nav2_get_backup_pose_action_bt_node"
   };
 
   declare_parameter_if_not_declared(

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -257,7 +257,6 @@ protected:
   // Publishers for the path
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr plan_publisher_;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr plan_publisher2_;
-  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PoseStamped>::SharedPtr goal_publisher2_;
 
   // Service to deterime if the path is valid
   rclcpp::Service<nav2_msgs::srv::IsPathValid>::SharedPtr is_path_valid_service_;

--- a/nav2_planner/include/nav2_planner/planner_server.hpp
+++ b/nav2_planner/include/nav2_planner/planner_server.hpp
@@ -257,6 +257,7 @@ protected:
   // Publishers for the path
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr plan_publisher_;
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>::SharedPtr plan_publisher2_;
+  rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PoseStamped>::SharedPtr goal_publisher2_;
 
   // Service to deterime if the path is valid
   rclcpp::Service<nav2_msgs::srv::IsPathValid>::SharedPtr is_path_valid_service_;

--- a/nav2_planner/src/planner_server.cpp
+++ b/nav2_planner/src/planner_server.cpp
@@ -564,7 +564,7 @@ PlannerServer::computePlan2()
     }
 
     // Publish the plan for visualization purposes
-    publishPlan(result->path);
+    publishPlan2(result->path);
 
     auto cycle_duration = this->now() - start_time;
     result->planning_time = cycle_duration;


### PR DESCRIPTION
- **GetBackupPose BT action node:** stores a backup_pose in a requested distance behind the robot while it moves
- **TimeoutController BT decorator node:** returns failure after its child did not finish within requested time
- Bug fixes in **truncate_path_local** and **planner_server**